### PR TITLE
Added 'roboto' font to Dockerfiles and get fontFamily from param

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation \
     fonts-noto-cjk \
     fonts-roboto \
+    fonts-croscore \
     libasound2 \
     libatk1.0-0 \
     libatk-bridge2.0-0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-dejavu \
     fonts-liberation \
     fonts-noto-cjk \
+    fonts-roboto \
     libasound2 \
     libatk1.0-0 \
     libatk-bridge2.0-0 \

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-liberation \
     fonts-noto-cjk \
     fonts-roboto \
+    fonts-croscore \
     libasound2 \
     libatk1.0-0 \
     libatk-bridge2.0-0 \

--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     fonts-dejavu \
     fonts-liberation \
     fonts-noto-cjk \
+    fonts-roboto \
     libasound2 \
     libatk1.0-0 \
     libatk-bridge2.0-0 \

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The service supports the following query params which may be passed to help cont
   - **includeResearchOutputs** Whether the research outputs should appear as an appendix page
   - **includeRelatedWorks** Whther the related works should be included as an appendix page
 - Font:
-  - **fontFamily** The font family to use (default is `Tinos, serif`)
+  - **fontFamily** The font family to use (default is `Tinos, serif`, with the other option being `Roboto, sans-serif`)
   - **fontSize** The size of the font in points (default is `11`, `8` to `14` allowed)
   - **lineHeight** The height of a standard line (default is `120`)
 - Margin
@@ -117,6 +117,7 @@ curl -v "http://localhost:3030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23
 ## Development
 
 To run this service locally, you must: 
+- Use the `development` branch
 - Have the [DMP Tool UI](https://github.com/CDLUC3/dmsp_frontend_prototype) docker environment running on your local machine. This service will allow you to login (obtain an auth cookie) and create/update DMP data which can then be used to generate narratives.
 - Have the [DMP Tool Apollo server](https://github.com/CDLUC3/dmsp_backend_prototype) docker environment running on your local machine. This service has a local DynamoDB Table with DMP records available for query.
 - Run `npm install` and then `docker compose up`

--- a/src/__tests__/helper.spec.ts
+++ b/src/__tests__/helper.spec.ts
@@ -1,4 +1,10 @@
-import { safeNumber, safeBoolean, pointsToFontSize, formatDate } from "../helper";
+import { 
+  safeNumber, 
+  safeBoolean, 
+  pointsToFontSize, 
+  formatDate,
+  getFontFamily
+ } from "../helper";
 
 describe("safeNumber", () => {
   it("parses valid numbers", () => {
@@ -81,5 +87,18 @@ describe("formatDate", () => {
   it("returns 'None specified' for invalid date", () => {
     const result = formatDate("not-a-date");
     expect(result).toBe("None specified");
+  });
+});
+
+describe("getFontFamily", () => {
+  it("returns a default font family for unknown values", () => {
+    expect(getFontFamily("unknown")).toBe("Tinos, serif");
+    expect(getFontFamily("")).toBe("Tinos, serif");
+    expect(getFontFamily("  ")).toBe("Tinos, serif");
+  });
+
+  it("returns the correct font family for known values", () => {
+    expect(getFontFamily("tinos")).toBe("Tinos, serif");
+    expect(getFontFamily("roboto")).toBe("Roboto, sans-serif");
   });
 });

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -46,3 +46,16 @@ export function formatDate(date: string, includeDay = true): string {
     return 'None specified';
   }
 }
+
+export function getFontFamily(fontParam: string): string {
+  // Define available fonts with their CSS declarations
+  const availableFonts = {
+    'tinos': 'Tinos, serif',
+    'roboto': 'Roboto, sans-serif'
+  };
+
+  // Will convert to lowercase, trim whitespace, and remove quotes
+  const selectedFont = fontParam?.toLowerCase().trim().replace(/['"]/g, '') || 'tinos';
+
+  return availableFonts[selectedFont] || availableFonts['tinos'];
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,7 +9,12 @@ import { renderPDF } from "./pdf";
 import { renderDOCX } from "./docx";
 import { renderTXT } from "./txt";
 import { initLogger, logger, prepareObjectForLogs } from "./logger";
-import { safeNumber, safeBoolean, pointsToFontSize } from "./helper";
+import {
+  safeNumber,
+  safeBoolean,
+  pointsToFontSize,
+  getFontFamily
+} from "./helper";
 import { expressjwt, Request } from "express-jwt";
 import { getDMP } from "./dynamo";
 import { MySQLConnection } from "./mysql";
@@ -92,7 +97,7 @@ function prepareOptions(params: any): OptionsInterface {
       marginLeft: safeNumber(params?.marginLeft as string, 96),
     },
     font: {
-      fontFamily: "Tinos, serif",
+      fontFamily: getFontFamily(params?.fontFamily as string),
       fontSize: pointsToFontSize(safeNumber(params?.fontSize as string, 11)),
       lineHeight: safeNumber(params?.lineHeight as string, 120),
     }


### PR DESCRIPTION
- Added `roboto` font to Dockerfiles
- Added helper function `getFontFamily` to get font from query params and fall back to `tinos`
- Updated server.ts to use `getFontFamily` to assign a font family
- Added unit test for `getFontFamily` function