### PR TITLE
Change cover page to show the title as top element and remove it from later paragraph

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ ENV=dev
 APP_NAME=dmp-tool-narrative-generator
 
 # The port this service should listen on
-PORT=3030
+PORT=4030
 
 # The logging level. Can be one of: `debug`, `info`, `warn`, `error`
 LOG_LEVEL=debug

--- a/README.md
+++ b/README.md
@@ -61,21 +61,21 @@ Note that you must have the application running using `npm run dev` for the foll
 
 Example with query parameters to adjust formatting:
 ```shell
-curl -v "http://localhost:3030/dmps/00.00000/A1B2C3/narrative?fontSize=13&marginLeft=5&includeCoverPage=false" \
+curl -v "http://localhost:4030/dmps/00.00000/A1B2C3/narrative?fontSize=13&marginLeft=5&includeCoverPage=false" \
 -H "Accept: text/html" 
 --output tmp/test.html
 ```
 
 Example of fetching a historical version of a DMP:
 ```shell
-curl -v "http://localhost:3030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
+curl -v "http://localhost:4030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
 -H "Accept: text/html"  
 --output tmp/test.html
 ```
 
 Example with Auth token as cookie:
 ```shell
-curl -v "http://localhost:3030/dmps/00.00000/A1B2C3/narrative" \
+curl -v "http://localhost:4030/dmps/00.00000/A1B2C3/narrative" \
 -H "Accept: text/html" 
 -b "dmspt=my-cookie"  
 --output tmp/test.html
@@ -84,32 +84,32 @@ curl -v "http://localhost:3030/dmps/00.00000/A1B2C3/narrative" \
 Examples for each format type:
 ```shell
 # CSV
-curl -v "http://localhost:3030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
+curl -v "http://localhost:4030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
 -H "Accept: text/csv" \
 --output tmp/dmp.csv
 
 # DOCX
-curl -v "http://localhost:3030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
+curl -v "http://localhost:4030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
 -H "Accept: application/vnd.openxmlformats-officedocument.wordprocessingml.document" \
 --output tmp/dmp.docx
 
 # HTML
-curl -v "http://localhost:3030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
+curl -v "http://localhost:4030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
 -H "Accept: text/html" 
 --output tmp/dmp.html  
 
 # JSON
-curl -v "http://localhost:3030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
+curl -v "http://localhost:4030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
 -H "Accept: text/html" 
 --output tmp/dmp.json
 
 # PDF
-curl -v "http://localhost:3030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
+curl -v "http://localhost:4030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
 -H "Accept: application/pdf" \
 --output tmp/dmp.pdf
 
 # TEXT
-curl -v "http://localhost:3030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
+curl -v "http://localhost:4030/dmps/00.00000/A1B2C3/narrative?version=2024-01-23T16:24:56Z" \
 -H "Accept: text/plain" \
 --output tmp/dmp.txt
 ```

--- a/src/html.ts
+++ b/src/html.ts
@@ -388,7 +388,7 @@ export function renderHTML(
     <body>
       {{#if ${display.includeCoverPage}}}
 
-        <h1>Plan Overview</h1>
+        <h1>{{title}}</h1>
         <hr>
         <div class="cover-page">
           <p class="header">
@@ -400,9 +400,6 @@ export function renderHTML(
               <a href="{{dmp_id.identifier}}" target="_blank">{{doiForDisplay dmp_id.identifier}}</a>
             </p>
           {{/if}}
-          <p>
-            <b>Title: </b>{{title}}
-          </p>
           <p>
             <strong>Creator:</strong> {{contact.name}} {{{contactIdentifierForDisplay contact.contact_id}}}
           </p>

--- a/src/server.ts
+++ b/src/server.ts
@@ -328,7 +328,7 @@ app.get("/narrative-health", (_: Request, res: Response) => res.send("ok"));
 // ----------------- Startup the server  -----------------
 const startServer = async () => {
   await sqlDataSource.initPromise;
-  const PORT = process.env.PORT || 3030;
+  const PORT = process.env.PORT || 4030;
   app.listen(PORT, () => console.log(`${process.env.APP_NAME} listening on port ${PORT}`));
 }
 


### PR DESCRIPTION
Fixes https://github.com/CDLUC3/dmptool-narrative-generator/issues/8 .

1) Changes the title of the cover page from "Plan Overview" to the title of the plan and then removes the title that appears below in the content of the page.

2) Updates the `README.md`, `.env.example` and `server.ts` to use port 4030 as default since that seems to be how the container runs now.

I went back and forth running both the container and `npm run dev` since neither seemed to work but `npm run dev` seemed to be giving me better output.  It turns out it was the port being incorrect as the reason I couldn't get connections.

Examples for testing in my environment are below and they need to have the dmspt value replaced with your actual cookie from your UI frontend from your web browser ( the front end should be running in docker and not `npm run dev`).

```
# PDF example
curl -v "http://localhost:4030/dmps/10.11111/999999999/narrative?fontSize=13&marginLeft=5&includeCoverPage=true" -H "Accept: application/pdf" -b "dmspt=dke...." --output dmp.pdf

# or HTML example
curl -v "http://localhost:4030/dmps/10.11111/999999999/narrative?fontSize=13&marginLeft=5&includeCoverPage=true" -H "Accept: text/html" -b "dmspt=eyJh..."
```