### PR TITLE
Updated html for researchOutputTables so list descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added this `CHANGELOG.md`, `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` files
 
 ## Updated
+- Updated the `html` rendering for `researchOutputTable` type answers by rendering all the descriptions above the table [#184]
 - Updated `puppeteer` and `turbodocx/html-to-docx` dependencies
 - Updated renovate config to rebase when behind the base branch
 - Fixed an issue with a check to determine if the maDMP is missing or just outdated

--- a/src/__tests__/html.spec.ts
+++ b/src/__tests__/html.spec.ts
@@ -346,9 +346,9 @@ describe("renderHtmlTemplate", () => {
                   columnHeadings: ["Title", "Description", "Output Type"],
                   answer: [{
                     columns: [
-                      { type: "text", answer: "My Software", meta: { schemaVersion: "1.0" } },
+                      { type: "text", answer: "Fatty acids from juvenile salmon", meta: { schemaVersion: "1.0" } },
                       { type: "textArea", answer: "<p>Some description</p>", meta: { schemaVersion: "1.0" } },
-                      { type: "selectBox", answer: "software_tool", meta: { schemaVersion: "1.0" } },
+                      { type: "selectBox", answer: "my_output_type", meta: { schemaVersion: "1.0" } },
                     ],
                   }],
                   meta: { schemaVersion: "1.0" },
@@ -361,8 +361,8 @@ describe("renderHtmlTemplate", () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } as any);
 
-    // "software_tool" → replace underscores → "software tool" → title case → "Software Tool"
-    expect(html).toContain('<h4>Software Tool - "My Software"</h4>');
+    // "my_output_type" → replace underscores → "my output type" → title case → "My Output Type"
+    expect(html).toContain('<h4>My Output Type - "Fatty acids from juvenile salmon"</h4>');
   });
 
   it("should use empty strings in researchOutputTable row summary when Title or Output Type headings are absent", () => {

--- a/src/__tests__/html.spec.ts
+++ b/src/__tests__/html.spec.ts
@@ -267,4 +267,138 @@ describe("renderHtmlTemplate", () => {
     expect(html).toContain("Empty Test");
     expect(html).not.toContain("Not answered"); // no questions
   });
+
+  const roBaseData = {
+    title: "Test Plan",
+    dmp_id: { identifier: "id", type: "other" },
+    contact: {
+      name: "Alice",
+      contact_id: { identifier: "id", type: "other" },
+      affiliation: [{ affiliation_id: { identifier: "id", type: "other" }, name: "Org" }],
+    },
+    contributor: [],
+    project: [],
+    description: "desc",
+    modified: "2024-01-01",
+  };
+
+  it("should render researchOutputTable row summaries using Title, Description, and Output Type column headings", () => {
+    const html = renderHTML(display, margin, font, {
+      ...roBaseData,
+      narrative: {
+        template: {
+          title: "T",
+          section: [{
+            title: "Research Outputs",
+            description: "",
+            order: 1,
+            question: [{
+              text: "Research outputs",
+              order: 1,
+              answer: {
+                json: {
+                  type: "researchOutputTable",
+                  columnHeadings: ["Title", "Description", "Output Type"],
+                  answer: [{
+                    columns: [
+                      { type: "text", answer: "My Dataset", meta: { schemaVersion: "1.0" } },
+                      { type: "textArea", answer: "<p>A description of the dataset</p>", meta: { schemaVersion: "1.0" } },
+                      { type: "selectBox", answer: "dataset", meta: { schemaVersion: "1.0" } },
+                    ],
+                  }],
+                  meta: { schemaVersion: "1.0" },
+                }
+              }
+            }]
+          }]
+        }
+      }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    // Row summary <h4> uses named column headings, with Output Type title-cased
+    expect(html).toContain('<h4>Dataset - "My Dataset"</h4>');
+    // Description content appears in the summary above the table
+    expect(html).toContain("A description of the dataset");
+    // Description is excluded from the table column headings
+    expect(html).not.toContain("<th>Description</th>");
+    // Title and Output Type remain as table column headings
+    expect(html).toContain("<th>Title</th>");
+    expect(html).toContain("<th>Output Type</th>");
+  });
+
+  it("should format the researchOutputTable Output Type with title case replacing hyphens and underscores", () => {
+    const html = renderHTML(display, margin, font, {
+      ...roBaseData,
+      narrative: {
+        template: {
+          title: "T",
+          section: [{
+            title: "Research Outputs",
+            description: "",
+            order: 1,
+            question: [{
+              text: "Research outputs",
+              order: 1,
+              answer: {
+                json: {
+                  type: "researchOutputTable",
+                  columnHeadings: ["Title", "Description", "Output Type"],
+                  answer: [{
+                    columns: [
+                      { type: "text", answer: "My Software", meta: { schemaVersion: "1.0" } },
+                      { type: "textArea", answer: "<p>Some description</p>", meta: { schemaVersion: "1.0" } },
+                      { type: "selectBox", answer: "software_tool", meta: { schemaVersion: "1.0" } },
+                    ],
+                  }],
+                  meta: { schemaVersion: "1.0" },
+                }
+              }
+            }]
+          }]
+        }
+      }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    // "software_tool" → replace underscores → "software tool" → title case → "Software Tool"
+    expect(html).toContain('<h4>Software Tool - "My Software"</h4>');
+  });
+
+  it("should use empty strings in researchOutputTable row summary when Title or Output Type headings are absent", () => {
+    const html = renderHTML(display, margin, font, {
+      ...roBaseData,
+      narrative: {
+        template: {
+          title: "T",
+          section: [{
+            title: "Research Outputs",
+            description: "",
+            order: 1,
+            question: [{
+              text: "Research outputs",
+              order: 1,
+              answer: {
+                json: {
+                  type: "researchOutputTable",
+                  columnHeadings: ["Description"],
+                  answer: [{
+                    columns: [
+                      { type: "textArea", answer: "<p>Only description</p>", meta: { schemaVersion: "1.0" } },
+                    ],
+                  }],
+                  meta: { schemaVersion: "1.0" },
+                }
+              }
+            }]
+          }]
+        }
+      }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+    // No Title or Output Type headings → both default to empty string
+    expect(html).toContain('<h4> - ""</h4>');
+    expect(html).toContain("Only description");
+  });
 });

--- a/src/html.ts
+++ b/src/html.ts
@@ -194,7 +194,19 @@ function answerToHTML(json: AnyAnswerType): string {
 
         const filteredCols = cols.filter((_, i) => !excludedIndices.has(i));
 
-        let table = "<table>";
+        // For each row, pull the description column and render it as a summary above the table, 
+        // then exclude it from the table itself
+        const stripPTagsFromHeader = (html: string) => html.replace(/^<p>|<\/p>$/g, "");
+        const rowSummaries = rows.map((row) => {
+          const col0 = stripPTagsFromHeader(researchOutputColumnToHTML(row.columns[0] as AnyAnswerType));
+          const col1 = researchOutputColumnToHTML(row.columns[1] as AnyAnswerType);
+          const col2 = stripPTagsFromHeader(researchOutputColumnToHTML(row.columns[2] as AnyAnswerType))
+            .replace(/[-_]/g, " ") // Replace hyphens and underscores with spaces
+            .replace(/\b\w/g, (c) => c.toUpperCase()); // Capitalize the first letter of each word to make it title case
+          return `<h4>${col2} - "${col0}"</h4>${col1}`;
+        }).join("");
+
+        let table = `${rowSummaries}<table>`;
 
         if (filteredCols.length > 0) {
           const ths = filteredCols.map((th) => `<th>${th}</th>`).join("");
@@ -204,6 +216,7 @@ function answerToHTML(json: AnyAnswerType): string {
         table += "<tbody>";
         table += rows.map((row) => {
           const tds = row.columns
+            .slice(0, cols.length)
             .filter((_, i) => !excludedIndices.has(i))
             .map((col) => `<td>${researchOutputColumnToHTML(col as AnyAnswerType)}</td>`)
             .join("");
@@ -513,6 +526,11 @@ export function renderHTML(
         h3 {
           font-size: 1.2em;
         }
+        h4 {
+          font-size: 1rem;
+          margin-left: 15px;
+          margin-bottom: 10px;
+        }
         div.cover-page p {
           margin-left: 10px;
           margin-bottom: 35px;
@@ -544,6 +562,10 @@ export function renderHTML(
         th, td {
           border: 1px solid black !important;
           padding: 2px;
+        }
+        td:first-child, th:first-child {
+          max-width: 300px;
+          word-wrap: break-word;
         }
         .annotations {
           margin-left: 15px;

--- a/src/html.ts
+++ b/src/html.ts
@@ -197,13 +197,19 @@ function answerToHTML(json: AnyAnswerType): string {
         // For each row, pull the description column and render it as a summary above the table, 
         // then exclude it from the table itself
         const stripPTagsFromHeader = (html: string) => html.replace(/^<p>|<\/p>$/g, "");
+        // Find the indices of the Title, Description, and Output Type columns for use in the row summaries
+        const titleIdx = cols.indexOf("Title");
+        const descriptionIdx = cols.indexOf("Description");
+        const outputTypeIdx = cols.indexOf("Output Type");
         const rowSummaries = rows.map((row) => {
-          const col0 = stripPTagsFromHeader(researchOutputColumnToHTML(row.columns[0] as AnyAnswerType));
-          const col1 = researchOutputColumnToHTML(row.columns[1] as AnyAnswerType);
-          const col2 = stripPTagsFromHeader(researchOutputColumnToHTML(row.columns[2] as AnyAnswerType))
-            .replace(/[-_]/g, " ") // Replace hyphens and underscores with spaces
-            .replace(/\b\w/g, (c) => c.toUpperCase()); // Capitalize the first letter of each word to make it title case
-          return `<h4>${col2} - "${col0}"</h4>${col1}`;
+          const title = titleIdx >= 0 ? stripPTagsFromHeader(researchOutputColumnToHTML(row.columns[titleIdx] as AnyAnswerType)) : "";
+          const description = descriptionIdx >= 0 ? researchOutputColumnToHTML(row.columns[descriptionIdx] as AnyAnswerType) : "";
+          const outputType = outputTypeIdx >= 0
+            ? stripPTagsFromHeader(researchOutputColumnToHTML(row.columns[outputTypeIdx] as AnyAnswerType))
+              .replace(/[-_]/g, " ") // Replace hyphens and underscores with spaces
+              .replace(/\b\w/g, (c) => c.toUpperCase()) // Capitalize the first letter of each word to make it title case
+            : "";
+          return `<h4>${outputType} - "${title}"</h4>${description}`;
         }).join("");
 
         let table = `${rowSummaries}<table>`;


### PR DESCRIPTION


## Description

- Updated the `html` rendering for `researchOutputTable` type answers by rendering all the descriptions above the table

Fixes # ([184](https://github.com/CDLUC3/dmptool-doc/issues/184))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested, downloading HTML and PDF files


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshot of a PDF generated
<img width="816" height="682" alt="image" src="https://github.com/user-attachments/assets/12101724-ea74-4544-880b-bfc22865d8fc" />
