### PR TITLE
Added additional comments to downloaded doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Added this `CHANGELOG.md`, `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` files
 
 ## Updated
-- Updated `html.ts`'s `answerToHTML` function to include additional comments in the download [#164]
+- Updated `html.ts`'s `answerToHTML` function to include additional comments in the download. Also, added additional comments text to `csv.ts` [#164]
 - Updated the `html` rendering for `researchOutputTable` type answers by rendering all the descriptions above the table [#184]
 - Updated `puppeteer` and `turbodocx/html-to-docx` dependencies
 - Updated renovate config to rebase when behind the base branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added this `CHANGELOG.md`, `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` files
 
 ## Updated
+- Updated `html.ts`'s `answerToHTML` function to include additional comments in the download [#164]
 - Updated the `html` rendering for `researchOutputTable` type answers by rendering all the descriptions above the table [#184]
 - Updated `puppeteer` and `turbodocx/html-to-docx` dependencies
 - Updated renovate config to rebase when behind the base branch

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@dmptool/types": "^3.1.3",
-        "@dmptool/utils": "^1.0.43",
+        "@dmptool/utils": "^2.0.0",
         "@elastic/ecs-pino-format": "^1.5.0",
         "@turbodocx/html-to-docx": "^1.20.1",
         "cookie-parser": "^1.4.7",
@@ -1876,9 +1876,9 @@
       }
     },
     "node_modules/@dmptool/utils": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@dmptool/utils/-/utils-1.0.43.tgz",
-      "integrity": "sha512-AL/5bhtFRMd3TcKoyLb16cm5xeMdSW9xB7alraCADmcEcyHwcfdF2HyyKfonqDIFnQa7/9CoE+oTLP5phQCZZw==",
+      "version": "2.0.0",
+      "resolved": "git+ssh://git@github.com/CDLUC3/dmptool-utils.git#b5fec11e2a8c0a8f38da472bf8cabdef7a6fee26",
+      "integrity": "sha512-qIfc+llYJytzFpHp8w9xC7VhHL83s0p/NA4c27Ha7+TKQoM3zC0CqoIyK0CKvvYLqlZPBbWISTfr91wy2DsBpQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@dmptool/types": "^3.1.3",
-    "@dmptool/utils": "^1.0.43",
+    "@dmptool/utils": "^2.0.0",
     "@elastic/ecs-pino-format": "^1.5.0",
     "@turbodocx/html-to-docx": "^1.20.1",
     "cookie-parser": "^1.4.7",

--- a/src/__tests__/csv.spec.ts
+++ b/src/__tests__/csv.spec.ts
@@ -1,3 +1,4 @@
+
 import { renderCSV } from "../csv";
 import {AnyAnswerType, TableAnswerType} from "@dmptool/types";
 import {DMPExtensionNarrative} from "@dmptool/utils";
@@ -26,8 +27,10 @@ describe("renderCsv + answerToCSV integration", () => {
         id: 123,
         title: "Section 1",
         order: 1,
+        type: "BASE",
         question: [{
           id: 123,
+          type: "BASE",
           text: "Q1",
           order: 1,
           answer: {
@@ -150,6 +153,19 @@ describe("renderCsv + answerToCSV integration", () => {
     const csv = renderCSV(baseDisplay, { narrative: { template: data } });
     const expected = "{\"\"type\"\":\"\"text\"\",\"\"answer\"\":\"\"row1col2\"\"";
     expect(csv).toContain(expected);
+  });
+
+  it("appends comment to answer", () => {
+    const data: DMPExtensionNarrative = wrap({
+      type: "textArea",
+      answer: "Just the answer",
+      comment: "This is a comment",
+      meta: {
+        schemaVersion: "1.0.0",
+      }
+    });
+    const csv = renderCSV(baseDisplay, { narrative: { template: data } });
+    expect(csv).toContain("Just the answer (Comment: This is a comment)");
   });
 });
 

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -11,7 +11,7 @@ import { stringify } from "csv-stringify/sync";
 import {DMPExtensionNarrative} from "@dmptool/utils";
 
 function answerToCSV (json: AnyAnswerType): string | number | boolean {
-  let answer: string | number | boolean;
+  let answer: string | number | boolean | undefined;
   // Special handling for certain answer types
   switch (json?.type as string) {
     case "textArea": {
@@ -48,7 +48,16 @@ function answerToCSV (json: AnyAnswerType): string | number | boolean {
       answer = json?.answer as string | number | boolean | undefined;
       break
   }
-  return answer ?? '';
+  // Normalize to string for CSV output
+  let finalAnswer = answer ?? '';
+
+  // 👇 Append comment if it exists
+  if (json?.comment) {
+    finalAnswer = `${finalAnswer} (Comment: ${json.comment})`;
+  }
+
+  return finalAnswer;
+
 }
 
 export function renderCSV(display: DisplayOptionsInterface, data: DMPToolDMPType["dmp"]): string {

--- a/src/html.ts
+++ b/src/html.ts
@@ -241,6 +241,12 @@ function answerToHTML(json: AnyAnswerType): string {
         break;
     }
   }
+
+  // Append comment if present
+  if (json.comment) {
+    out += `<div class="answer-comment"><strong>Comment:</strong> ${json.comment}</div>`;
+  }
+
   return out;
 }
 


### PR DESCRIPTION
## Description

- Updated `html.ts`'s `answerToHTML` function to include additional comments in the download [#164]

Fixes # ([164](https://github.com/CDLUC3/dmptool-doc/issues/164))

## Type of change
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested with the updates in `dmptool-utils`


## Checklist:
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I updated the CHANGELOG.md and added documentation if necessary
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [*] Any dependent changes have been merged and published in downstream modules
*Note: backend dependency from `dmptool-utils`. There is a PR open for it here: https://github.com/CDLUC3/dmptool-utils/pull/15